### PR TITLE
Add level select support

### DIFF
--- a/scenes/ui/LevelSelect.tscn
+++ b/scenes/ui/LevelSelect.tscn
@@ -1,0 +1,58 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/LevelSelect.gd" id="1_script"]
+
+[node name="LevelSelect" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_script")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.12, 0.12, 0.12, 1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -300.0
+offset_top = -250.0
+offset_right = 300.0
+offset_bottom = 250.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 30
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 48
+text = "Select Level"
+horizontal_alignment = 1
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/h_separation = 20
+theme_override_constants/v_separation = 20
+columns = 5
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+custom_minimum_size = Vector2(200, 60)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 24
+text = "Back"
+
+[connection signal="pressed" from="VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]

--- a/scenes/ui/PauseMenu.tscn
+++ b/scenes/ui/PauseMenu.tscn
@@ -38,6 +38,10 @@ horizontal_alignment = 1
 layout_mode = 2
 text = "Resume"
 
+[node name="LevelSelectButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Level Select"
+
 [node name="MenuButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 text = "Main Menu"
@@ -47,5 +51,6 @@ layout_mode = 2
 text = "Quit Game"
 
 [connection signal="pressed" from="VBoxContainer/ResumeButton" to="." method="_on_resume_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/LevelSelectButton" to="." method="_on_level_select_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/MenuButton" to="." method="_on_menu_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/QuitButton" to="." method="_on_quit_button_pressed"]

--- a/scenes/ui/TitleScreen.tscn
+++ b/scenes/ui/TitleScreen.tscn
@@ -56,10 +56,16 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "Start Game"
 
+[node name="LevelSelectButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Level Select"
+
 [node name="ExitButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "Exit"
 
 [connection signal="pressed" from="VBoxContainer/StartButton" to="." method="_on_start_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/LevelSelectButton" to="." method="_on_level_select_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/ExitButton" to="." method="_on_exit_button_pressed"]

--- a/scripts/ui/LevelSelect.gd
+++ b/scripts/ui/LevelSelect.gd
@@ -1,0 +1,30 @@
+extends Control
+
+@onready var grid = $VBoxContainer/GridContainer
+
+func _ready() -> void:
+	_generate_level_buttons()
+	$VBoxContainer/BackButton.grab_focus()
+
+func _generate_level_buttons():
+	for i in range(1, 21):
+		var btn = Button.new()
+		btn.text = "Level " + str(i)
+		btn.custom_minimum_size = Vector2(100, 60)
+		btn.theme_override_font_sizes/font_size = 18
+		
+		var level_path = ""
+		if i == 1:
+			level_path = "res://scenes/Main.tscn"
+		else:
+			level_path = "res://scenes/levels/Level" + str(i) + ".tscn"
+			
+		btn.pressed.connect(_on_level_button_pressed.bind(level_path))
+		grid.add_child(btn)
+
+func _on_level_button_pressed(path: String):
+	get_tree().paused = false # Ensure game is unpaused if coming from pause menu
+	get_tree().change_scene_to_file(path)
+
+func _on_back_button_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/ui/TitleScreen.tscn")

--- a/scripts/ui/PauseMenu.gd
+++ b/scripts/ui/PauseMenu.gd
@@ -16,6 +16,10 @@ func toggle_pause():
 func _on_resume_button_pressed() -> void:
 	toggle_pause()
 
+func _on_level_select_button_pressed() -> void:
+	toggle_pause() # Unpause
+	get_tree().change_scene_to_file("res://scenes/ui/LevelSelect.tscn")
+
 func _on_menu_button_pressed() -> void:
 	toggle_pause() # Unpause before changing scene
 	get_tree().change_scene_to_file("res://scenes/ui/TitleScreen.tscn")

--- a/scripts/ui/TitleScreen.gd
+++ b/scripts/ui/TitleScreen.gd
@@ -8,5 +8,8 @@ func _ready() -> void:
 func _on_start_button_pressed() -> void:
 	get_tree().change_scene_to_file("res://scenes/Main.tscn")
 
+func _on_level_select_button_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/ui/LevelSelect.tscn")
+
 func _on_exit_button_pressed() -> void:
 	get_tree().quit()


### PR DESCRIPTION
This PR adds a level select menu accessible from both the Title Screen and the Pause Menu.

### Changes:
- New LevelSelect.tscn scene with a grid of buttons for levels 1-20.
- LevelSelect.gd script to dynamically generate level buttons and handle navigation.
- Added 'Level Select' buttons to TitleScreen.tscn and PauseMenu.tscn.
- Updated respective scripts to handle the new button functionality.

Fixes #2