### PR TITLE
Fix hovering and sinking sprites

### DIFF
--- a/scenes/actors/Enemy.tscn
+++ b/scenes/actors/Enemy.tscn
@@ -37,6 +37,7 @@ collision_mask = 3
 script = ExtResource("1_script")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(0, 4.7)
 scale = Vector2(0.1, 0.1)
 sprite_frames = SubResource("SpriteFrames_turtle")
 animation = &"walk"

--- a/scenes/actors/EnemyFlying.tscn
+++ b/scenes/actors/EnemyFlying.tscn
@@ -37,6 +37,7 @@ collision_mask = 3
 script = ExtResource("1_script")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(0, 1.3)
 scale = Vector2(0.1, 0.1)
 sprite_frames = SubResource("SpriteFrames_bat")
 animation = &"fly"

--- a/scenes/actors/EnemyFlyingTurtle.tscn
+++ b/scenes/actors/EnemyFlyingTurtle.tscn
@@ -23,6 +23,7 @@ collision_mask = 3
 script = ExtResource("1_script")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(0, 3)
 scale = Vector2(0.08, 0.08)
 sprite_frames = SubResource("SpriteFrames_fly")
 animation = &"fly"

--- a/scenes/actors/EnemyMushroom.tscn
+++ b/scenes/actors/EnemyMushroom.tscn
@@ -23,6 +23,7 @@ collision_mask = 3
 script = ExtResource("1_script")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(0, 0.6)
 scale = Vector2(0.08, 0.08)
 sprite_frames = SubResource("SpriteFrames_mush")
 animation = &"walk"

--- a/scenes/actors/Player.tscn
+++ b/scenes/actors/Player.tscn
@@ -51,6 +51,7 @@ collision_layer = 2
 script = ExtResource("1_script")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(0, -3.4)
 scale = Vector2(0.2, 0.2)
 sprite_frames = SubResource("SpriteFrames_player")
 animation = &"idle"


### PR DESCRIPTION
This PR adjusts the vertical positioning of the AnimatedSprite2D nodes for the Player and all Enemy types to ensure their feet align correctly with the ground level of their collision shapes.

### Changes:
- Adjusted position.y of AnimatedSprite2D in:
  - Player.tscn (-3.4)
  - Enemy.tscn (+4.7)
  - EnemyMushroom.tscn (+0.6)
  - EnemyFlying.tscn (+1.3)
  - EnemyFlyingTurtle.tscn (+3.0)

Calculations were based on the pixel bounds of the source assets relative to the centered frame.

Fixes #3