### PR TITLE
Add fall death and respawn mechanics

### DIFF
--- a/scripts/GameState.gd
+++ b/scripts/GameState.gd
@@ -39,7 +39,16 @@ func take_damage(amount: int):
 	health_changed.emit(health)
 	sfx_damage.play()
 	if health <= 0:
-		call_deferred("game_over")
+		game_over()
+
+func respawn():
+	health -= 1
+	health_changed.emit(health)
+	sfx_damage.play()
+	if health <= 0:
+		game_over()
+	else:
+		get_tree().reload_current_scene()
 
 func game_over():
 	get_tree().change_scene_to_file("res://scenes/ui/GameOver.tscn")

--- a/scripts/actors/Player.gd
+++ b/scripts/actors/Player.gd
@@ -3,6 +3,7 @@ extends CharacterBody2D
 @export var speed: float = 300.0
 @export var jump_velocity: float = -400.0
 @export var max_jumps: int = 2
+@export var death_y_threshold: float = 1000.0
 
 var jump_count: int = 0
 # Get the gravity from the project settings to be synced with RigidBody nodes.
@@ -22,6 +23,10 @@ func _on_health_changed(new_health: int) -> void:
 	tween.tween_property(self, "modulate", Color.WHITE, 0.1)
 
 func _physics_process(delta: float) -> void:
+	# Check for falling off the level
+	if global_position.y > death_y_threshold:
+		GameState.respawn()
+
 	# Add the gravity.
 	if not is_on_floor():
 		velocity.y += gravity * delta


### PR DESCRIPTION
Implements a death threshold for the player. If they fall below Y=1000, they lose 1 health and the current level reloads. If health reaches 0, it's Game Over.

Fixes #11