### PR TITLE
Add splash screen before title screen

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="2D Scroller Game"
-run/main_scene="res://scenes/ui/TitleScreen.tscn"
+run/main_scene="res://scenes/ui/SplashScreen.tscn"
 config/features=PackedStringArray("4.5", "Forward Plus")
 config/icon="res://icon.svg"
 

--- a/scenes/ui/SplashScreen.tscn
+++ b/scenes/ui/SplashScreen.tscn
@@ -1,0 +1,66 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/SplashScreen.gd" id="1_script"]
+
+[node name="SplashScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_script")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.1, 0.1, 0.15, 1)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
+layout_mode = 2
+theme_override_constants/separation = 60
+
+[node name="TitleLabel" type="Label" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_x = 3
+theme_override_constants/shadow_offset_y = 3
+theme_override_font_sizes/font_size = 80
+text = "Jump Game"
+horizontal_alignment = 1
+
+[node name="SubtitleLabel" type="Label" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.7, 0.7, 1)
+theme_override_font_sizes/font_size = 24
+text = "A 2D Platformer Adventure"
+horizontal_alignment = 1
+
+[node name="BottomMargin" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -80.0
+grow_horizontal = 2
+grow_vertical = 0
+
+[node name="SkipLabel" type="Label" parent="BottomMargin"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
+theme_override_font_sizes/font_size = 20
+text = "Press ESC, ENTER, or START to continue..."
+horizontal_alignment = 1

--- a/scripts/ui/SplashScreen.gd
+++ b/scripts/ui/SplashScreen.gd
@@ -1,0 +1,32 @@
+extends Control
+
+@export var title_screen_path: String = "res://scenes/ui/TitleScreen.tscn"
+@export var display_time: float = 3.0
+
+var elapsed_time: float = 0.0
+
+func _ready() -> void:
+	# Fade in animation
+	modulate = Color(1, 1, 1, 0)
+	var tween = create_tween()
+	tween.tween_property(self, "modulate", Color(1, 1, 1, 1), 0.5)
+
+func _process(delta: float) -> void:
+	elapsed_time += delta
+
+	# Check for skip inputs
+	if Input.is_action_just_pressed("ui_accept") or \
+	   Input.is_action_just_pressed("ui_cancel") or \
+	   Input.is_action_just_pressed("pause"):
+		_go_to_title_screen()
+		return
+
+	# Auto-advance after display time
+	if elapsed_time >= display_time:
+		_go_to_title_screen()
+
+func _go_to_title_screen() -> void:
+	# Fade out before transition
+	var tween = create_tween()
+	tween.tween_property(self, "modulate", Color(1, 1, 1, 0), 0.3)
+	tween.tween_callback(func(): get_tree().change_scene_to_file(title_screen_path))


### PR DESCRIPTION
## Summary
Implements a splash screen that displays before the main menu.

## Changes
- Created `SplashScreen.tscn` scene with game title and subtitle
- Created `SplashScreen.gd` script with auto-advance and skip functionality
- Updated `project.godot` to set splash screen as entry point
- Added fade in/out transitions

## Features
- Displays for 3 seconds before auto-advancing to title screen
- Can be skipped by pressing ESC, ENTER, or START button
- Smooth fade in/out animations

## Testing
✅ Splash screen displays correctly on game start
✅ Skip functionality works with all input methods
✅ Auto-advance works after 3 seconds
✅ Transitions to title screen properly

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)