### PR TITLE
Fix physics callback errors in enemy and object scripts

### DIFF
--- a/scripts/actors/Enemy.gd
+++ b/scripts/actors/Enemy.gd
@@ -72,13 +72,13 @@ func _on_hitbox_body_entered(body: Node2D) -> void:
 func die():
 	is_dying = true
 	GameState.play_kill_sound()
-	
-	# Disable collisions
+
+	# Disable collisions (use set_deferred for physics properties)
 	collision_layer = 0
 	collision_mask = 0
-	hitbox.monitoring = false
-	hitbox.monitorable = false
-	
+	hitbox.set_deferred("monitoring", false)
+	hitbox.set_deferred("monitorable", false)
+
 	# Bounce up
 	velocity.x = 0
 	velocity.y = -400.0

--- a/scripts/actors/EnemyFlying.gd
+++ b/scripts/actors/EnemyFlying.gd
@@ -72,7 +72,7 @@ func die():
 	GameState.play_kill_sound()
 	collision_layer = 0
 	collision_mask = 0
-	hitbox.monitoring = false
-	hitbox.monitorable = false
+	hitbox.set_deferred("monitoring", false)
+	hitbox.set_deferred("monitorable", false)
 	velocity.x = 0
 	velocity.y = -400.0

--- a/scripts/objects/Coin.gd
+++ b/scripts/objects/Coin.gd
@@ -8,6 +8,5 @@ func _ready() -> void:
 func _on_body_entered(body: Node2D) -> void:
 	if body.is_in_group("player"):
 		GameState.add_score(value)
-		# Add a nice little tween for feedback before deleting?
-		# For now, just disappear.
-		queue_free()
+		# Defer removal to avoid issues during physics callback
+		call_deferred("queue_free")

--- a/scripts/objects/Goal.gd
+++ b/scripts/objects/Goal.gd
@@ -9,7 +9,8 @@ func _on_body_entered(body: Node2D) -> void:
 	if body.is_in_group("player"):
 		print("Level Complete!")
 		GameState.complete_level()
+		# Defer scene change to avoid modifying scene tree during physics callback
 		if next_level_path != "":
-			get_tree().change_scene_to_file(next_level_path)
+			get_tree().call_deferred("change_scene_to_file", next_level_path)
 		else:
-			get_tree().change_scene_to_file("res://scenes/ui/Victory.tscn")
+			get_tree().call_deferred("change_scene_to_file", "res://scenes/ui/Victory.tscn")


### PR DESCRIPTION
## Summary
Fixes all physics callback violations that were causing console errors during gameplay.

## Problem
The game was generating numerous errors when:
- Enemies were defeated by the player
- Player reached the goal
- Player collected coins

These errors occurred because the code was attempting to modify physics-related properties and the scene tree during physics callbacks, which Godot prohibits for thread-safety reasons.

## Changes

### Enemy Scripts
**Enemy.gd** (lines 79-80):
- Changed `hitbox.monitoring = false` to `hitbox.set_deferred("monitoring", false)`
- Changed `hitbox.monitorable = false` to `hitbox.set_deferred("monitorable", false)`

**EnemyFlying.gd** (lines 75-76):
- Same fixes as Enemy.gd

### Object Scripts
**Goal.gd** (lines 13-16):
- Changed `get_tree().change_scene_to_file()` to `get_tree().call_deferred("change_scene_to_file")`
- Prevents scene tree modification during physics callback

**Coin.gd** (line 13):
- Changed `queue_free()` to `call_deferred("queue_free")`
- Defers node removal until safe to execute

## Errors Fixed
✅ `Function blocked during in/out signal. Use set_deferred("monitoring", true/false)`
✅ `Function blocked during in/out signal. Use set_deferred("monitorable", true/false)`
✅ `Removing a CollisionObject node during a physics callback is not allowed`

## Testing
✅ Played through Level 1 and Level 2
✅ Defeated multiple enemies - no errors
✅ Collected coins - no errors
✅ Reached goal and transitioned to next level - no errors
✅ Game runs cleanly without any physics callback warnings

All functionality works exactly as before, but now without console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)