### PR TITLE
Add developer credit and extend splash screen display time

### DIFF
--- a/scenes/ui/SplashScreen.tscn
+++ b/scenes/ui/SplashScreen.tscn
@@ -48,6 +48,13 @@ theme_override_font_sizes/font_size = 24
 text = "A 2D Platformer Adventure"
 horizontal_alignment = 1
 
+[node name="DeveloperLabel" type="Label" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.5, 0.5, 0.5, 1)
+theme_override_font_sizes/font_size = 18
+text = "Developed by Paul Hoke"
+horizontal_alignment = 1
+
 [node name="BottomMargin" type="MarginContainer" parent="."]
 layout_mode = 1
 anchors_preset = 12

--- a/scripts/ui/SplashScreen.gd
+++ b/scripts/ui/SplashScreen.gd
@@ -1,7 +1,7 @@
 extends Control
 
 @export var title_screen_path: String = "res://scenes/ui/TitleScreen.tscn"
-@export var display_time: float = 3.0
+@export var display_time: float = 5.0
 
 var elapsed_time: float = 0.0
 


### PR DESCRIPTION
## Summary
Updates the splash screen with developer attribution and extends the display time for better user experience.

## Changes

### Developer Credit
- Added "Developed by Paul Hoke" label to splash screen
- Positioned below the game subtitle
- Styled with subtle gray color (50% gray, 18pt font)
- Horizontally centered for professional appearance

### Display Time
- Increased auto-advance time from 3 seconds to 5 seconds
- Allows users more time to read all splash screen content
- Skip functionality unchanged (ESC, ENTER, or START)

## Visual Layout
The splash screen now displays:
1. **Jump Game** (main title, large)
2. **A 2D Platformer Adventure** (subtitle, medium gray)
3. **Developed by Paul Hoke** (credit, subtle gray)
4. Skip instructions at bottom

## Testing
✅ Splash screen displays developer credit correctly
✅ Auto-advance works after 5 seconds
✅ Skip functionality still works immediately
✅ All text properly centered and readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)